### PR TITLE
Small refactoring and modernization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["riva", "tuner", "rivatuner", "statistics", "server"]
 categories = ["external-ffi-bindings"]
 
 [build-dependencies]
-bindgen = "0.66"
+bindgen = "0.71"
 
 [dependencies]
-windows = { version = "0.48", features = ["Win32_Foundation", "Win32_System_Memory", "Win32_UI_WindowsAndMessaging"] }
+windows = { version = "0.58", features = ["Win32_System_Memory", "Win32_UI_WindowsAndMessaging"] }

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,3 @@
-extern crate bindgen;
-
 use std::env;
 use std::path::PathBuf;
 
@@ -8,10 +6,13 @@ fn main() {
 
     let include = "C:\\Program Files (x86)\\RivaTuner Statistics Server\\SDK\\Include";
     let bindings = bindgen::Builder::default()
+        .raw_line("#![allow(unused, non_camel_case_types, non_snake_case)]")
+        .raw_line("#![allow(clippy::unreadable_literal, clippy::upper_case_acronyms)]")
         .header("wrapper.h")
         .clang_args(["-I", include])
         .clang_args(["-x", "c++"])
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        .allowlist_file(".*\\\\RTSSSharedMemory.h")
         .generate()
         .expect("Unable to generate bindings");
 

--- a/wrapper.h
+++ b/wrapper.h
@@ -1,25 +1,2 @@
-#define MAX_PATH 260
-typedef __int64 LONGLONG;
-typedef float FLOAT;
-typedef int BOOL;
-typedef long LONG;
-typedef unsigned char BYTE;
-typedef BYTE *PBYTE;
-typedef BYTE *LPBYTE;
-typedef unsigned long DWORD;
-typedef union _LARGE_INTEGER
-{
-    struct
-    {
-        DWORD LowPart;
-        LONG HighPart;
-    } DUMMYSTRUCTNAME;
-    struct
-    {
-        DWORD LowPart;
-        LONG HighPart;
-    } u;
-    LONGLONG QuadPart;
-} LARGE_INTEGER;
-
+#include <Windows.h>
 #include <RTSSSharedMemory.h>


### PR DESCRIPTION
- Use windows.h instead of local copy of some constants/typedefs
- Update dependencies
- Use RTSS's fields to calculate offset, as it's done in SDK example ("for compatibility with future versions")